### PR TITLE
Updated Travis-CI node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: node_js
 node_js:
+- 'node'
+- 'iojs'
+- '6'
+- '5'
+- '4'
+- '0.12'
+- '0.11'
 - '0.10'
 before_script:
 - sudo apt-get install duplicity


### PR DESCRIPTION
I might use node-duplicity in a project and need to make a few improvements and updates.
For now i have updated the travis-ci node versions to the newest and it passed all.